### PR TITLE
Strip leading zero's of /soc/sram@180000

### DIFF
--- a/arch/arm/mach-imx/pm-imx7.c
+++ b/arch/arm/mach-imx/pm-imx7.c
@@ -1148,7 +1148,7 @@ void __init imx7d_pm_init(void)
 
 		/* map the m4 bootrom from dtb */
 		np = of_find_node_by_path(
-			"/soc/sram@00180000");
+			"/soc/sram@180000");
 		if (np)
 			m4_bootrom_base = of_iomap(np, 0);
 		WARN_ON(!m4_bootrom_base);


### PR DESCRIPTION
This is the path used by the device tree in imx7d.dtsi.
	ocrams: sram@180000 {
			compatible = "fsl,lpm-sram";
			reg = <0x180000 0x8000>;
			clocks = <&clks IMX7D_OCRAM_S_CLK>;
			status = "disabled";
		};