### PR TITLE
imx6-var-dvk: Fix bootlogo hdmi

### DIFF
--- a/drivers/video/fbdev/core/fbcon.c
+++ b/drivers/video/fbdev/core/fbcon.c
@@ -73,6 +73,7 @@
 #include <linux/selection.h>
 #include <linux/font.h>
 #include <linux/smp.h>
+#include <linux/linux_logo.h>
 #include <linux/init.h>
 #include <linux/interrupt.h>
 #include <linux/crc32.h> /* For counting font checksums */
@@ -539,6 +540,27 @@ static int search_for_mapped_con(void)
 	return retval;
 }
 
+static void update_logo_shown(struct vc_data *vc)
+{
+#ifdef CONFIG_LOGO
+ 	if (!logo_lines || (fg_console != vc->vc_num))
+ 		return;
+
+ 	if (fb_logos_freed()) {
+ 		logo_shown = FBCON_LOGO_CANSHOW;
+ 		return;
+ 	}
+
+	if (logo_lines > vc->vc_bottom) {
+		logo_shown = FBCON_LOGO_CANSHOW;
+		pr_info("fbcon_init: boot-logo may be bigger than screen.\n");
+ 	} else if (logo_shown != FBCON_LOGO_DONTSHOW) {
+ 		logo_shown = FBCON_LOGO_DRAW;
+ 		vc->vc_top = logo_lines;
+ 	}
+#endif
+}
+
 static int do_fbcon_takeover(int show_logo)
 {
 	int err, i;
@@ -652,6 +674,7 @@ static void fbcon_prepare_logo(struct vc_data *vc, struct fb_info *info,
 	if (logo_shown == FBCON_LOGO_DONTSHOW)
 		return;
 
+#if 0
 	if (logo_lines > vc->vc_bottom) {
 		logo_shown = FBCON_LOGO_CANSHOW;
 		printk(KERN_INFO
@@ -661,6 +684,8 @@ static void fbcon_prepare_logo(struct vc_data *vc, struct fb_info *info,
 		vc->vc_top = logo_lines;
 	}
 }
+#endif
+	update_logo_shown(vc);
 #endif /* MODULE */
 
 #ifdef CONFIG_FB_TILEBLITTING
@@ -2087,8 +2112,9 @@ static int fbcon_switch(struct vc_data *vc)
 		if (conp2->vc_top == logo_lines
 		    && conp2->vc_bottom == conp2->vc_rows)
 			conp2->vc_top = 0;
-		logo_shown = FBCON_LOGO_CANSHOW;
+/*		logo_shown = FBCON_LOGO_CANSHOW; */
 	}
+	update_logo_shown(vc);
 
 	prev_console = ops->currcon;
 	if (prev_console != -1)

--- a/drivers/video/fbdev/mxc/mxc_ipuv3_fb.c
+++ b/drivers/video/fbdev/mxc/mxc_ipuv3_fb.c
@@ -1124,6 +1124,7 @@ static int mxcfb_set_par(struct fb_info *fbi)
 	int ov_pos_ret = 0;
 	struct mxcfb_info *mxc_fbi_fg = NULL;
 	bool ovfbi_enable = false, on_the_fly;
+		int prev_line_length;
 
 	if (ipu_ch_param_bad_alpha_pos(fbi_to_pixfmt(fbi, true)) &&
 	    mxc_fbi->alpha_chan_en) {
@@ -1204,6 +1205,7 @@ static int mxcfb_set_par(struct fb_info *fbi)
 	if (mxc_fbi->first_set_par && mxc_fbi->late_init)
 		ipu_disable_hsp_clk(mxc_fbi->ipu);
 
+		prev_line_length = fbi->fix.line_length;
 	mem_len = fbi->var.yres_virtual * fbi->fix.line_length;
 	if (mxc_fbi->resolve && mxc_fbi->gpu_sec_buf_off) {
 		if (fbi->var.vmode & FB_VMODE_YWRAP)
@@ -1218,6 +1220,11 @@ static int mxcfb_set_par(struct fb_info *fbi)
 
 		if (mxcfb_map_video_memory(fbi) < 0)
 			return -ENOMEM;
+         } else {
+ 		if (prev_line_length && (prev_line_length != fbi->fix.line_length)) {
+ 			memset((char *)fbi->screen_base, 0, fbi->fix.smem_len);
+ 			mxc_fbi->first_set_par = false;
+		}
 	}
 
 	if (mxc_fbi->first_set_par) {

--- a/drivers/video/logo/logo.c
+++ b/drivers/video/logo/logo.c
@@ -37,6 +37,11 @@ static int __init fb_logo_late_init(void)
 
 late_initcall_sync(fb_logo_late_init);
 
+bool fb_logos_freed(void)
+{
+	return logos_freed;
+}
+
 /* logo's are marked __initdata. Use __ref to tell
  * modpost that it is intended that this function uses data
  * marked __initdata.

--- a/include/linux/linux_logo.h
+++ b/include/linux/linux_logo.h
@@ -47,6 +47,7 @@ extern const struct linux_logo logo_superh_clut224;
 extern const struct linux_logo logo_spe_clut224;
 extern const struct linux_logo logo_variscite_clut224;
 
+extern bool fb_logos_freed(void);
 extern const struct linux_logo *fb_find_logo(int depth);
 #ifdef CONFIG_FB_LOGO_EXTRA
 extern void fb_append_extra_logo(const struct linux_logo *logo,


### PR DESCRIPTION
Fixes #16
ported from 5.4 boundary devices kernel
https://github.com/boundarydevices/linux/commit/531de831b3c465f2b8602f26cbdef25afe47af5d https://github.com/boundarydevices/linux/commit/d1c959481f4a6381996cd370c3ca214c62a307f5 https://github.com/boundarydevices/linux/commit/6709ca50fcd66c3ac5dfe4d19e8423815c0552f3