### PR TITLE
Make irq-imx-irqsteer build without PM_SLEEP

### DIFF
--- a/drivers/irqchip/irq-imx-irqsteer.c
+++ b/drivers/irqchip/irq-imx-irqsteer.c
@@ -191,7 +191,7 @@ static int imx_irqsteer_chans_enable(struct irqsteer_data *data)
 {
 	int ret;
 
-	ret = clk_prepare_enable(irqsteer_data->ipg_clk);
+	ret = clk_prepare_enable(data->ipg_clk);
 	if (ret) {
 		dev_err(data->dev, "failed to enable ipg clk: %d\n", ret);
 		return ret;

--- a/drivers/irqchip/irq-imx-irqsteer.c
+++ b/drivers/irqchip/irq-imx-irqsteer.c
@@ -378,7 +378,6 @@ static int imx_irqsteer_runtime_resume(struct device *dev)
 
 	return 0;
 }
-#endif
 
 static const struct dev_pm_ops imx_irqsteer_pm_ops = {
 	SET_NOIRQ_SYSTEM_SLEEP_PM_OPS(pm_runtime_force_suspend,
@@ -386,6 +385,11 @@ static const struct dev_pm_ops imx_irqsteer_pm_ops = {
 	SET_RUNTIME_PM_OPS(imx_irqsteer_runtime_suspend,
 			   imx_irqsteer_runtime_resume, NULL)
 };
+
+#define IRQSTEER_PM_OPS_PTR (&imx_irqsteer_pm_ops)
+#else
+#define IRQSTEER_PM_OPS_PTR NULL
+#endif
 
 static const struct of_device_id imx_irqsteer_dt_ids[] = {
 	{ .compatible = "fsl,imx-irqsteer", },
@@ -397,7 +401,7 @@ static struct platform_driver imx_irqsteer_driver = {
 	.driver = {
 		.name = "imx-irqsteer",
 		.of_match_table = imx_irqsteer_dt_ids,
-		.pm = &imx_irqsteer_pm_ops,
+		.pm = IRQSTEER_PM_OPS_PTR,
 	},
 	.probe = imx_irqsteer_probe,
 	.remove = imx_irqsteer_remove,


### PR DESCRIPTION
The current version fails to build, if PM_SLEEP is not defined:

```
/build/tmp/work-shared/machine/kernel-source/drivers/irqchip/irq-imx-irqsteer.c: In function 'imx_irqsteer_chans_enable':
/build/tmp/work-shared/machine/kernel-source/drivers/irqchip/irq-imx-irqsteer.c:194:34: error: 'irqsteer_data' undeclared (first use in this function)
  194 |         ret = clk_prepare_enable(irqsteer_data->ipg_clk);
      |                                  ^~~~~~~~~~~~~
/build/tmp/work-shared/machine/kernel-source/drivers/irqchip/irq-imx-irqsteer.c:194:34: note: each undeclared identifier is reported only once for each function it appears in
In file included from /build/tmp/work-shared/machine/kernel-source/include/linux/device.h:25,
                 from /build/tmp/work-shared/machine/kernel-source/include/linux/of_platform.h:9,
                 from /build/tmp/work-shared/machine/kernel-source/drivers/irqchip/irq-imx-irqsteer.c:15:
/build/tmp/work-shared/machine/kernel-source/drivers/irqchip/irq-imx-irqsteer.c: At top level:
/build/tmp/work-shared/machine/kernel-source/drivers/irqchip/irq-imx-irqsteer.c:386:28: error: 'imx_irqsteer_runtime_suspend' undeclared here (not in a function); did you mean 'pm_generic_runtime_suspend'?
  386 |         SET_RUNTIME_PM_OPS(imx_irqsteer_runtime_suspend,
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/tmp/work-shared/machine/kernel-source/include/linux/pm.h:341:28: note: in definition of macro 'SET_RUNTIME_PM_OPS'
  341 |         .runtime_suspend = suspend_fn, \
      |                            ^~~~~~~~~~
/build/tmp/work-shared/machine/kernel-source/drivers/irqchip/irq-imx-irqsteer.c:387:28: error: 'imx_irqsteer_runtime_resume' undeclared here (not in a function)
  387 |                            imx_irqsteer_runtime_resume, NULL)
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/build/tmp/work-shared/machine/kernel-source/include/linux/pm.h:342:27: note: in definition of macro 'SET_RUNTIME_PM_OPS'
  342 |         .runtime_resume = resume_fn, \
      |                           ^~~~~~~~~
make[2]: *** [/build/tmp/work-shared/machine/kernel-source/scripts/Makefile.build:289: drivers/irqchip/irq-imx-irqsteer.o] Error 1
make[1]: *** [/build/tmp/work-shared/machine/kernel-source/scripts/Makefile.build:552: drivers/irqchip] Error 2
```